### PR TITLE
Add support for requesting SPIFFE JWT SVIDs

### DIFF
--- a/WebApp/.vscode/launch.json
+++ b/WebApp/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/InspectorGadget.WebApp.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/WebApp/.vscode/launch.json
+++ b/WebApp/.vscode/launch.json
@@ -13,7 +13,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/InspectorGadget.WebApp.dll",
+            "program": "${workspaceFolder}/bin/Debug/net6.0/InspectorGadget.WebApp.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
@@ -34,5 +34,7 @@
             "type": "coreclr",
             "request": "attach"
         }
+       
+        
     ]
 }

--- a/WebApp/.vscode/tasks.json
+++ b/WebApp/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/InspectorGadget.WebApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/InspectorGadget.WebApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/InspectorGadget.WebApp.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/WebApp/AppSettings.cs
+++ b/WebApp/AppSettings.cs
@@ -54,6 +54,7 @@ namespace InspectorGadget.WebApp
         public ConfigurableHealthCheckMode DefaultHealthCheckMode => configuration.GetValueOrDefault("DefaultHealthCheckMode", ConfigurableHealthCheckMode.AlwaysSucceed);
         public int DefaultHealthCheckFailNumberOfTimes => configuration.GetValueOrDefault("DefaultHealthCheckFailNumberOfTimes", 10);
 
+        public bool DisableSPIFFE => configuration.GetValueOrDefault("DisableSPIFFE", false);
         public AppSettings(IConfiguration configuration)
         {
             this.configuration = configuration;

--- a/WebApp/Gadgets/SPIFFE/SPIFFEWorkloadApiGadget.cs
+++ b/WebApp/Gadgets/SPIFFE/SPIFFEWorkloadApiGadget.cs
@@ -81,6 +81,9 @@ namespace InspectorGadget.WebApp.Gadgets
                     // NO SVID was assigned
                     result.Message = "No SVID was assigned.  Grpc status code was PermissionDenied with detail: no identity issued";
                 }
+                else{
+                    result.Message = $"Grpc status code: {exc.StatusCode} - Detail: {exc.Status.Detail}";
+                }
             }
             return result;
         }

--- a/WebApp/Gadgets/SPIFFE/SPIFFEWorkloadApiGadget.cs
+++ b/WebApp/Gadgets/SPIFFE/SPIFFEWorkloadApiGadget.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Net.Client;
+using InspectorGadget.WebApp.Controllers;
+using InspectorGadget.WebApp.Infrastructure;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace InspectorGadget.WebApp.Gadgets
+{
+    public class SPIFFEWorkloadApiGadget : GadgetBase<SPIFFEWorkloadApiGadget.Request, SPIFFEWorkloadApiGadget.Result>
+    {
+        public class Request : GadgetRequest
+        {
+            public string UnixDomainSocketEndpoint { get; set; }
+            public string Audience { get; set; }
+
+        }
+
+        public class Result
+        {
+            public IDictionary<string, string> JwtTokens { get; set; }
+            public string Message { get; set; }
+
+            public Result(){
+                JwtTokens = new Dictionary<string, string>();
+            }
+        }
+
+        public SPIFFEWorkloadApiGadget(ILogger logger, IHttpClientFactory httpClientFactory, IUrlHelper url, AppSettings appSettings) : 
+                                  base(logger, httpClientFactory, url.GetRelativeApiUrl("TODO"), appSettings.DisableSPIFFE){
+
+        }
+
+        private async Task<Result> FetchJwtSVID(string unixDomainSocketEndpoint, string audience){
+            // Prepare Channel
+            var udsEndPoint = new UnixDomainSocketEndPoint(unixDomainSocketEndpoint); // default is "/tmp/spire-agent/public/api.sock"
+            var connectionFactory = new UnixDomainSocketConnectionFactory(udsEndPoint);
+            var socketsHttpHandler = new SocketsHttpHandler
+            {
+                ConnectCallback = connectionFactory.ConnectAsync
+            };
+
+            using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+            {
+                HttpHandler = socketsHttpHandler
+            });
+
+            // Prepare client
+            var client = new SPIFFE.SpiffeWorkloadAPI.SpiffeWorkloadAPIClient(channel);
+
+            // SPIFFE request
+            var req = new SPIFFE.JWTSVIDRequest(){
+                // SpiffeId = SpiffeId => only needed when a specific SPIFFE ID is requested
+            };
+            req.Audience.Add(audience);
+            
+            // SPIFFE metadata
+            Metadata headers = new();
+            headers.Add("workload.spiffe.io","true");
+
+            // Call SPIFFE workload endpoint
+            Result result = new();
+            try{
+                using var call = client.FetchJWTSVIDAsync(req, headers);
+                var response = await call.ResponseAsync;
+                foreach(var svid in response.Svids){
+                    result.JwtTokens.Add(svid.SpiffeId, svid.Svid);
+                }
+            }
+            catch(RpcException exc){
+                if(exc.Status.StatusCode == StatusCode.PermissionDenied && exc.Status.Detail == "no identity issued"){
+                    // NO SVID was assigned
+                    result.Message = "No SVID was assigned.  Grpc status code was PermissionDenied with detail: no identity issued";
+                }
+            }
+            return result;
+        }
+
+        protected override async Task<Result> ExecuteCoreAsync(Request request)
+        {
+            return await FetchJwtSVID(request.UnixDomainSocketEndpoint, request.Audience);
+        }
+    }
+
+    public class UnixDomainSocketConnectionFactory
+    {
+        private readonly EndPoint _endPoint;
+
+        public UnixDomainSocketConnectionFactory(EndPoint endPoint)
+        {
+            _endPoint = endPoint;
+        }
+
+        public async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext _,
+            CancellationToken cancellationToken = default)
+        {
+            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+
+            try
+            {
+                await socket.ConnectAsync(_endPoint, cancellationToken).ConfigureAwait(false);
+                return new NetworkStream(socket, true);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+        }
+    }
+}

--- a/WebApp/Gadgets/SPIFFE/protos/workloadapi.proto
+++ b/WebApp/Gadgets/SPIFFE/protos/workloadapi.proto
@@ -1,0 +1,164 @@
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+
+service SpiffeWorkloadAPI {
+    /////////////////////////////////////////////////////////////////////////
+    // X509-SVID Profile
+    /////////////////////////////////////////////////////////////////////////
+
+    // Fetch X.509-SVIDs for all SPIFFE identities the workload is entitled to,
+    // as well as related information like trust bundles and CRLs. As this
+    // information changes, subsequent messages will be streamed from the
+    // server.
+    rpc FetchX509SVID(X509SVIDRequest) returns (stream X509SVIDResponse);
+
+    // Fetch trust bundles and CRLs. Useful for clients that only need to
+    // validate SVIDs without obtaining an SVID for themself. As this
+    // information changes, subsequent messages will be streamed from the
+    // server.
+    rpc FetchX509Bundles(X509BundlesRequest) returns (stream X509BundlesResponse);
+
+    /////////////////////////////////////////////////////////////////////////
+    // JWT-SVID Profile
+    /////////////////////////////////////////////////////////////////////////
+
+    // Fetch JWT-SVIDs for all SPIFFE identities the workload is entitled to,
+    // for the requested audience. If an optional SPIFFE ID is requested, only
+    // the JWT-SVID for that SPIFFE ID is returned.
+    rpc FetchJWTSVID(JWTSVIDRequest) returns (JWTSVIDResponse);
+
+    // Fetches the JWT bundles, formatted as JWKS documents, keyed by the
+    // SPIFFE ID of the trust domain. As this information changes, subsequent
+    // messages will be streamed from the server.
+    rpc FetchJWTBundles(JWTBundlesRequest) returns (stream JWTBundlesResponse);
+
+    // Validates a JWT-SVID against the requested audience. Returns the SPIFFE
+    // ID of the JWT-SVID and JWT claims.
+    rpc ValidateJWTSVID(ValidateJWTSVIDRequest) returns (ValidateJWTSVIDResponse);
+}
+
+// The X509SVIDRequest message conveys parameters for requesting an X.509-SVID.
+// There are currently no request parameters.
+message X509SVIDRequest {  }
+
+// The X509SVIDResponse message carries X.509-SVIDs and related information,
+// including a set of global CRLs and a list of bundles the workload may use
+// for federating with foreign trust domains.
+message X509SVIDResponse {
+    // Required. A list of X509SVID messages, each of which includes a single
+    // X.509-SVID, its private key, and the bundle for the trust domain.
+    repeated X509SVID svids = 1;
+
+    // Optional. ASN.1 DER encoded certificate revocation lists.
+    repeated bytes crl = 2;
+
+    // Optional. CA certificate bundles belonging to foreign trust domains that
+    // the workload should trust, keyed by the SPIFFE ID of the foreign trust
+    // domain. Bundles are ASN.1 DER encoded.
+    map<string, bytes> federated_bundles = 3;
+}
+
+// The X509SVID message carries a single SVID and all associated information,
+// including the X.509 bundle for the trust domain.
+message X509SVID {
+    // Required. The SPIFFE ID of the SVID in this entry
+    string spiffe_id = 1;
+
+    // Required. ASN.1 DER encoded certificate chain. MAY include
+    // intermediates, the leaf certificate (or SVID itself) MUST come first.
+    bytes x509_svid = 2;
+
+    // Required. ASN.1 DER encoded PKCS#8 private key. MUST be unencrypted.
+    bytes x509_svid_key = 3;
+
+    // Required. ASN.1 DER encoded X.509 bundle for the trust domain.
+    bytes bundle = 4;
+
+    // Optional. An operator-specified string used to provide guidance on how this
+    // identity should be used by a workload when more than one SVID is returned.
+    // For example, `internal` and `external` to indicate an SVID for internal or
+    // external use, respectively.
+    string hint = 5;
+}
+
+// The X509BundlesRequest message conveys parameters for requesting X.509
+// bundles. There are currently no such parameters.
+message X509BundlesRequest {
+}
+
+// The X509BundlesResponse message carries a set of global CRLs and a map of
+// trust bundles the workload should trust.
+message X509BundlesResponse {
+    // Optional. ASN.1 DER encoded certificate revocation lists.
+    repeated bytes crl = 1;
+
+    // Required. CA certificate bundles belonging to trust domains that the
+    // workload should trust, keyed by the SPIFFE ID of the trust domain.
+    // Bundles are ASN.1 DER encoded.
+    map<string, bytes> bundles = 2;
+}
+
+message JWTSVIDRequest {
+    // Required. The audience(s) the workload intends to authenticate against.
+    repeated string audience = 1;
+
+    // Optional. The requested SPIFFE ID for the JWT-SVID. If unset, all
+    // JWT-SVIDs to which the workload is entitled are requested.
+    string spiffe_id = 2;
+}
+
+// The JWTSVIDResponse message conveys JWT-SVIDs.
+message JWTSVIDResponse {
+    // Required. The list of returned JWT-SVIDs.
+    repeated JWTSVID svids = 1;
+}
+
+// The JWTSVID message carries the JWT-SVID token and associated metadata.
+message JWTSVID {
+    // Required. The SPIFFE ID of the JWT-SVID.
+    string spiffe_id = 1;
+
+    // Required. Encoded JWT using JWS Compact Serialization.
+    string svid = 2;
+
+    // Optional. An operator-specified string used to provide guidance on how this
+    // identity should be used by a workload when more than one SVID is returned.
+    // For example, `internal` and `external` to indicate an SVID for internal or
+    // external use, respectively.
+    string hint = 3;
+}
+
+// The JWTBundlesRequest message conveys parameters for requesting JWT bundles.
+// There are currently no such parameters.
+message JWTBundlesRequest { }
+
+// The JWTBundlesReponse conveys JWT bundles.
+message JWTBundlesResponse {
+    // Required. JWK encoded JWT bundles, keyed by the SPIFFE ID of the trust
+    // domain.
+    map<string, bytes> bundles = 1;
+}
+
+// The ValidateJWTSVIDRequest message conveys request parameters for
+// JWT-SVID validation.
+message ValidateJWTSVIDRequest {
+    // Required. The audience of the validating party. The JWT-SVID must
+    // contain an audience claim which contains this value in order to
+    // succesfully validate.
+    string audience = 1;
+
+    // Required. The JWT-SVID to validate, encoded using JWS Compact
+    // Serialization.
+    string svid = 2;
+}
+
+// The ValidateJWTSVIDReponse message conveys the JWT-SVID validation results.
+message ValidateJWTSVIDResponse {
+    // Required. The SPIFFE ID of the validated JWT-SVID.
+    string spiffe_id = 1;
+
+    // Required. Claims contained within the payload of the validated JWT-SVID.
+    // This includes both SPIFFE-required and non-required claims.
+    google.protobuf.Struct claims = 2;
+}

--- a/WebApp/Gadgets/SPIFFE/protos/workloadapi.proto
+++ b/WebApp/Gadgets/SPIFFE/protos/workloadapi.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+option csharp_namespace = "InspectorGadget.WebApp.Gadgets.SPIFFE";
 
 import "google/protobuf/struct.proto";
 

--- a/WebApp/InspectorGadget.WebApp.csproj
+++ b/WebApp/InspectorGadget.WebApp.csproj
@@ -1,17 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.46.0" />
+    <!-- Grpc to call into SPIFFE workload API -->
+    <PackageReference Include="Grpc.Tools" Version="2.46.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.12" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.18.0-preview" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.0" />
     <PackageReference Include="MySqlConnector" Version="1.3.2" />
     <PackageReference Include="Npgsql" Version="5.0.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Grpc client lib generation for SPIFFE workload API -->
+    <Protobuf Include="Gadgets\SPIFFE\protos\workloadapi.proto" />
   </ItemGroup>
 
 </Project>

--- a/WebApp/Pages/Shared/DisplayTemplates/SPIFFEWorkloadApiGadgetResult.cshtml
+++ b/WebApp/Pages/Shared/DisplayTemplates/SPIFFEWorkloadApiGadgetResult.cshtml
@@ -1,0 +1,27 @@
+@model SPIFFEWorkloadApiGadget.Result
+@if (!String.IsNullOrWhiteSpace(Model.Message)){
+    <h6 class="card-subtitle mb-2 text-muted">Message</h6>
+    <div>@Model.Message</div>
+}
+
+@if (Model.JwtTokens != null && Model.JwtTokens.Any())
+{
+    <h6 class="card-subtitle mb-2 text-muted mt-3">SVIDs received</h6>
+    <table class="table table-striped table-hover table-sm table-bordered">
+        <thead>
+        <tr>
+            <th>SVID</th>
+            <th>JWT Token</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach (var token in Model.JwtTokens)
+        {
+        <tr>
+            <td class="inspector-key text-nowrap">@token.Key</td>
+            <td class="inspector-value"><a href="https://jwt.ms/#access_token=@(token.Value)" target="_blank" title="Decode this access token">decode</a></td>
+        </tr>
+        }
+        </tbody>
+    </table>
+}

--- a/WebApp/Pages/Shared/_Layout.cshtml
+++ b/WebApp/Pages/Shared/_Layout.cshtml
@@ -51,6 +51,10 @@
                         {
                         <li class="nav-item"><a class="nav-link text-dark" asp-page="/Introspector" title="Introspector">Introspector</a></li>
                         }
+                        @if(!AppSettings.DisableSPIFFE)
+                        {
+                        <li class="nav-item"><a class="nav-link text-dark" asp-page="/Spiffe" title="SPIFFE">SPIFFE </a></li>
+                        }
                         <li class="nav-item"><a class="nav-link text-dark" asp-page="/Api" title="API">API</a></li>
                     </ul>
                 </div>

--- a/WebApp/Pages/Spiffe.cshtml
+++ b/WebApp/Pages/Spiffe.cshtml
@@ -15,10 +15,10 @@
         <label for="audience">Audience</label>
         <input type="text" name="audience" id="audience" value="@Model.GadgetRequest.Audience" class="form-control val-required" placeholder="The audience requested within the SPIFFE JWT token" title="" />
     </div>
-    <div class="form-group">
+    @* <div class="form-group">
         <label for="callChainUrls"><a asp-page="/Api" asp-fragment="call-chaining">Call Chain</a></label>
         <input type="text" name="callChainUrls" id="callChainUrls" value="@Model.GadgetRequest.CallChainUrls" class="form-control val-optional" placeholder="Optionally chain calls across multiple hops (separate base URL's by spaces)" title="You can set the default value as a 'DefaultCallChainUrls' configuration setting" />
-    </div>
+    </div> *@
     <div class="form-group">
         <input type="submit" value="Submit" class="btn btn-primary" />
     </div> 

--- a/WebApp/Pages/Spiffe.cshtml
+++ b/WebApp/Pages/Spiffe.cshtml
@@ -1,0 +1,27 @@
+﻿@page
+@model MyApp.Namespace.SpiffeModel
+@{
+    ViewData["Title"] = "SPIFFE";
+}
+<h1>@ViewData["Title"]</h1>
+
+<form method="POST">
+    <p class="text-muted">Query the SPIFFE workload API if available.</p>
+    <div class="form-group">
+        <label for="unixdomainsocketep">Unix Domain Socket Endpoint to use to communicate to Agent</label>
+        <input type="text" name="unixdomainsocketendpoint" id="unixdomainsocketendpoint" value="@Model.GadgetRequest.UnixDomainSocketEndpoint" class="form-control val-required" placeholder="The unix domain socket endpoint to perform the GRPC SPIFFE request against (default is /tmp/spire-agent/public/api.sock)" title="" />
+    </div>
+    <div class="form-group">
+        <label for="audience">Audience</label>
+        <input type="text" name="audience" id="audience" value="@Model.GadgetRequest.Audience" class="form-control val-required" placeholder="The audience requested within the SPIFFE JWT token" title="" />
+    </div>
+    <div class="form-group">
+        <label for="callChainUrls"><a asp-page="/Api" asp-fragment="call-chaining">Call Chain</a></label>
+        <input type="text" name="callChainUrls" id="callChainUrls" value="@Model.GadgetRequest.CallChainUrls" class="form-control val-optional" placeholder="Optionally chain calls across multiple hops (separate base URL's by spaces)" title="You can set the default value as a 'DefaultCallChainUrls' configuration setting" />
+    </div>
+    <div class="form-group">
+        <input type="submit" value="Submit" class="btn btn-primary" />
+    </div> 
+</form>
+
+@Html.DisplayFor(m => m.GadgetResponse)

--- a/WebApp/Pages/Spiffe.cshtml.cs
+++ b/WebApp/Pages/Spiffe.cshtml.cs
@@ -1,0 +1,39 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using InspectorGadget.WebApp;
+using InspectorGadget.WebApp.Gadgets;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+
+namespace MyApp.Namespace
+{
+    public class SpiffeModel : PageModel
+    {
+        private readonly ILogger logger;
+        private readonly IHttpClientFactory httpClientFactory;
+        private readonly AppSettings appSettings;
+
+        [BindProperty]
+        public SPIFFEWorkloadApiGadget.Request GadgetRequest { get; set; }
+
+        public GadgetResponse<SPIFFEWorkloadApiGadget.Result> GadgetResponse { get; set; }
+
+        public SpiffeModel(ILogger<SpiffeModel> logger, IHttpClientFactory httpClientFactory, AppSettings appSettings){
+            this.logger = logger;
+            this.httpClientFactory = httpClientFactory;
+            this.appSettings = appSettings;
+            this.GadgetRequest = new (){
+                UnixDomainSocketEndpoint = "/tmp/spire-agent/public/api.sock",
+                Audience = "someaudience"
+            };
+        }
+
+        public async Task OnPost()
+        {
+            this.logger.LogInformation("Executing SPIFFE workload API query");
+            var gadget = new SPIFFEWorkloadApiGadget(this.logger, this.httpClientFactory, Url, this.appSettings);
+            this.GadgetResponse = await gadget.ExecuteAsync(this.GadgetRequest);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for doing a GRPC request to a SPIFFE Workload API to acquire a JWT SVID.  The request is local, using Unix Domain Sockets.  To build this support, the project was upgraded with absolute minimal changes to .NET 6.0.  (No optimizations.)

Limitations:
- no support for calling the workload API on Windows
- no support for calling the workload API over TCP (discouraged by the spec)
- no support for call chaining (yet)
- no support for calling other RCP APIs on the SPIFFE workload endpoint